### PR TITLE
Fix missing key skills in CV generator

### DIFF
--- a/cv_generator.py
+++ b/cv_generator.py
@@ -1,12 +1,16 @@
+"""Generate a CV in DOCX format from structured JSON content."""
+
 import json
 from docx import Document
 from docx.shared import Pt, Cm
 from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
 from docx.enum.style import WD_STYLE_TYPE
 
+
 def load_cv_content(filename):
     with open(filename, 'r') as file:
         return json.load(file)
+
 
 def create_cv(content):
     doc = Document()
@@ -47,6 +51,13 @@ def create_cv(content):
     doc.add_paragraph('Professional Summary', style='CustomHeading')
     doc.add_paragraph(content['professional_summary'])
 
+    # Key Skills
+    if content.get('key_skills'):
+        doc.add_paragraph('Key Skills', style='CustomHeading')
+        for skill in content['key_skills']:
+            skill_para = doc.add_paragraph(skill, style='List Bullet')
+            skill_para.paragraph_format.space_after = Pt(0)
+
     # Accomplishments
     doc.add_paragraph('Accomplishments', style='CustomHeading')
     for accomplishment in content['accomplishments']:
@@ -75,6 +86,7 @@ def create_cv(content):
         para.paragraph_format.space_after = Pt(0)
 
     return doc
+
 
 if __name__ == "__main__":
     cv_content = load_cv_content('cv_content.json')


### PR DESCRIPTION
## Summary
- add module docstring and clean up spacing for PEP8 compliance
- include key skills section when generating CV

## Testing
- `flake8 --ignore=E501`
- `python3 cv_generator.py > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_683f708e5b348320afed219f36423761