### PR TITLE
Add Key Skills section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !.gitignore
 *docx
 old/
+__pycache__/

--- a/cv_generator.py
+++ b/cv_generator.py
@@ -47,6 +47,12 @@ def create_cv(content):
     doc.add_paragraph('Professional Summary', style='CustomHeading')
     doc.add_paragraph(content['professional_summary'])
 
+    # Key Skills
+    doc.add_paragraph('Key Skills', style='CustomHeading')
+    for skill in content.get('key_skills', []):
+        para = doc.add_paragraph(skill, style='List Bullet')
+        para.paragraph_format.space_after = Pt(0)
+
     # Accomplishments
     doc.add_paragraph('Accomplishments', style='CustomHeading')
     for accomplishment in content['accomplishments']:

--- a/tests/test_cv_generator.py
+++ b/tests/test_cv_generator.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from cv_generator import create_cv
+
+def minimal_content():
+    return {
+        'personal_info': {'name': 'Name', 'contact': 'Contact'},
+        'professional_summary': 'Summary.',
+        'key_skills': ['Skill1', 'Skill2'],
+        'accomplishments': [],
+        'work_history': [],
+        'education': [],
+        'certifications': []
+    }
+
+def test_key_skills_section_present():
+    doc = create_cv(minimal_content())
+    texts = [p.text for p in doc.paragraphs]
+    assert 'Key Skills' in texts
+    index = texts.index('Key Skills')
+    assert texts[index + 1] == 'Skill1'
+    assert texts[index + 2] == 'Skill2'
+    assert doc.paragraphs[index].style.name == 'CustomHeading'
+    assert doc.paragraphs[index + 1].style.name == 'List Bullet'


### PR DESCRIPTION
## Summary
- include `Key Skills` section in the generated CV
- bullet list skills from content
- add corresponding unit test
- ignore `__pycache__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f72781a80832092e068d2fee961fc