### PR TITLE
Add tests for cv_generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 !.gitignore
 *docx
 old/
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # cv_generator
+
+This project generates a CV document from structured JSON data using `python-docx`.
+
+## Running tests
+
+Unit tests use `pytest`. Install dependencies and run tests with:
+
+```bash
+pip install python-docx pytest
+pytest
+```

--- a/tests/test_cv_generator.py
+++ b/tests/test_cv_generator.py
@@ -1,0 +1,17 @@
+import pytest
+from docx.document import Document as DocumentClass
+import cv_generator
+
+
+def test_load_cv_content_returns_dict():
+    content = cv_generator.load_cv_content('cv_content.json')
+    assert isinstance(content, dict)
+
+
+def test_create_cv_returns_document_instance():
+    content = cv_generator.load_cv_content('cv_content.json')
+    doc = cv_generator.create_cv(content)
+    assert isinstance(doc, DocumentClass)
+    # Verify that at least the 'Professional Summary' heading is present
+    texts = [p.text for p in doc.paragraphs]
+    assert 'Professional Summary' in texts


### PR DESCRIPTION
## Summary
- add unit tests for `cv_generator`
- document running tests in README
- ignore caches in `.gitignore`

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f727c531c832091019e6b445828c3