### PR TITLE
Improve tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@ This repository contains a simple Python script for creating a curriculum vitae 
 ## Current Workflow
 
 1. Edit `cv_content.json` with your personal details.
-2. Run `cv_generator.py` to create a CV document called `Joan_Marc_Riera_CV.docx`.
+2. Run `python cv_generator.py` to create a CV document called
+   `Joan_Marc_Riera_CV.docx` in the project folder.
 
 The script sets up page margins and basic styles, then writes the contents of `cv_content.json` to the document. Only the fields present in the JSON file are used.
 
 ## Getting Started
 
+It is recommended to work inside a virtual environment so dependencies do not
+pollute your system installation. Create and activate one with:
+
 ```bash
-# Install requirements
+python -m venv venv
+source venv/bin/activate
+```
+
+Install the required packages:
+
+```bash
 pip install python-docx pytest
 ```
 

--- a/cv_generator.py
+++ b/cv_generator.py
@@ -30,7 +30,9 @@ def create_cv(content):
     font.size = Pt(10)
 
     # Create a custom style for headings
-    heading_style = doc.styles.add_style('CustomHeading', WD_STYLE_TYPE.PARAGRAPH)
+    heading_style = doc.styles.add_style(
+        'CustomHeading', WD_STYLE_TYPE.PARAGRAPH
+    )
     heading_style.font.name = 'Calibri'
     heading_style.font.size = Pt(12)
     heading_style.font.bold = True
@@ -58,7 +60,6 @@ def create_cv(content):
             skill_para = doc.add_paragraph(skill, style='List Bullet')
             skill_para.paragraph_format.space_after = Pt(0)
 
-
     # Accomplishments
     doc.add_paragraph('Accomplishments', style='CustomHeading')
     for accomplishment in content['accomplishments']:
@@ -67,7 +68,8 @@ def create_cv(content):
     # Work History
     doc.add_paragraph('Work History', style='CustomHeading')
     for position in content['work_history']:
-        doc.add_paragraph(f"{position['title']} ({position['dates']})", style='CustomHeading')
+        title_line = f"{position['title']} ({position['dates']})"
+        doc.add_paragraph(title_line, style='CustomHeading')
         company = doc.add_paragraph(position['company'])
         company.style = 'Intense Quote'
         for responsibility in position['responsibilities']:

--- a/tests/test_cv_generator.py
+++ b/tests/test_cv_generator.py
@@ -2,10 +2,11 @@ import os
 import sys
 import pytest
 from docx.document import Document as DocumentClass
-import cv_generator
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from cv_generator import create_cv
+import cv_generator  # noqa: E402
+from cv_generator import create_cv  # noqa: E402
+
 
 def minimal_content():
     return {
@@ -18,6 +19,18 @@ def minimal_content():
         'certifications': []
     }
 
+
+def content_without_optional():
+    return {
+        'personal_info': {'name': 'Name', 'contact': 'Contact'},
+        'professional_summary': 'Summary.',
+        'accomplishments': [],
+        'work_history': [],
+        'education': [],
+        'certifications': []
+    }
+
+
 def test_key_skills_section_present():
     doc = create_cv(minimal_content())
     texts = [p.text for p in doc.paragraphs]
@@ -28,9 +41,16 @@ def test_key_skills_section_present():
     assert doc.paragraphs[index].style.name == 'CustomHeading'
     assert doc.paragraphs[index + 1].style.name == 'List Bullet'
 
+
 def test_load_cv_content_returns_dict():
     content = cv_generator.load_cv_content('cv_content.json')
     assert isinstance(content, dict)
+
+
+def test_load_cv_content_raises_for_missing_file(tmp_path):
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        cv_generator.load_cv_content(missing)
 
 
 def test_create_cv_returns_document_instance():
@@ -41,3 +61,8 @@ def test_create_cv_returns_document_instance():
     texts = [p.text for p in doc.paragraphs]
     assert 'Professional Summary' in texts
 
+
+def test_create_cv_handles_missing_optional_sections():
+    doc = create_cv(content_without_optional())
+    texts = [p.text for p in doc.paragraphs]
+    assert 'Key Skills' not in texts


### PR DESCRIPTION
## Summary
- fix flake8 errors and add small refactor in `cv_generator.py`
- expand unit tests and handle optional sections
- enhance README with venv instructions and clearer workflow

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7b3168b48320b9cd2ac0e2af7a52