### PR TITLE
Add CLI and template features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This repository contains a simple Python script for creating a curriculum vitae 
 ## Current Workflow
 
 1. Edit `cv_content.json` with your personal details.
-2. Run `python cv_generator.py` to create a CV document called
-   `Joan_Marc_Riera_CV.docx` in the project folder.
+2. Run `python cv_generator.py -o Joan_Marc_Riera_CV.docx` to create your CV.
 
 The script sets up page margins and basic styles, then writes the contents of `cv_content.json` to the document. Only the fields present in the JSON file are used.
 
@@ -23,7 +22,7 @@ source venv/bin/activate
 Install the required packages:
 
 ```bash
-pip install python-docx pytest
+pip install python-docx docxtpl pytest
 ```
 
 ## Running tests
@@ -31,22 +30,22 @@ pip install python-docx pytest
 Unit tests use `pytest`. Install dependencies and run tests with:
 
 ```bash
-pip install python-docx pytest
+pip install python-docx docxtpl pytest
 pytest
 ```
 ## Usage
 
-After populating `cv_content.json` with your CV details, run:
+After populating `cv_content.json` with your CV details, generate a CV with:
 
 ```bash
-python cv_generator.py
+python cv_generator.py -i cv_content.json -o My_CV.docx
 ```
 
-This will output a Word document in the repository folder.
+You can also specify a DOCX template using `-t TEMPLATE.docx`.
 
 ## Suggested Improvements
 
-The goal of the project is to quickly tailor CVs and cover letters for specific companies. To achieve this, consider extending the script with the following features:
+The goal of the project is to quickly tailor CVs and cover letters for specific companies. The script now provides a basic command line interface but could be further extended with features such as:
 
 * **Templating** – Allow multiple docx templates or sections to be assembled depending on the target company. This enables focused CVs with relevant skills and experience highlighted.
 * **Cover Letter Generation** – Add support for a cover letter template. The script could read a different JSON file or template fields to populate with company‑specific details (job title, contact person, etc.).

--- a/cv_generator.py
+++ b/cv_generator.py
@@ -1,6 +1,7 @@
 """Generate a CV in DOCX format from structured JSON content."""
 
 import json
+import argparse
 from docx import Document
 from docx.shared import Pt, Cm
 from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
@@ -12,8 +13,17 @@ def load_cv_content(filename):
         return json.load(file)
 
 
-def create_cv(content):
-    doc = Document()
+def create_cv(content, template=None):
+    """Create a CV Document.
+
+    Parameters
+    ----------
+    content : dict
+        Parsed JSON content describing the CV.
+    template : str, optional
+        Path to a .docx file to use as a starting template.
+    """
+    doc = Document(template) if template else Document()
 
     # Set page margins
     sections = doc.sections
@@ -91,7 +101,35 @@ def create_cv(content):
     return doc
 
 
+def parse_args(args=None):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Generate a CV from JSON data")
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="cv_content.json",
+        help="Path to JSON file with CV content",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="Joan_Marc_Riera_CV.docx",
+        help="Output DOCX file name",
+    )
+    parser.add_argument(
+        "-t",
+        "--template",
+        help="Optional DOCX template to use",
+    )
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    options = parse_args(args)
+    content = load_cv_content(options.input)
+    doc = create_cv(content, template=options.template)
+    doc.save(options.output)
+
+
 if __name__ == "__main__":
-    cv_content = load_cv_content('cv_content.json')
-    cv = create_cv(cv_content)
-    cv.save("Joan_Marc_Riera_CV.docx")
+    main()

--- a/tests/test_cv_generator.py
+++ b/tests/test_cv_generator.py
@@ -5,7 +5,7 @@ from docx.document import Document as DocumentClass
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import cv_generator  # noqa: E402
-from cv_generator import create_cv  # noqa: E402
+from cv_generator import create_cv, main  # noqa: E402
 
 
 def minimal_content():
@@ -66,3 +66,22 @@ def test_create_cv_handles_missing_optional_sections():
     doc = create_cv(content_without_optional())
     texts = [p.text for p in doc.paragraphs]
     assert 'Key Skills' not in texts
+
+
+def test_cli_creates_output_file(tmp_path):
+    output = tmp_path / "cv.docx"
+    main(["-i", "cv_content.json", "-o", str(output)])
+    assert output.exists()
+
+
+def test_create_cv_with_template(tmp_path):
+    template_path = tmp_path / "template.docx"
+    # create a simple template with a placeholder paragraph
+    from docx import Document
+    template_doc = Document()
+    template_doc.add_paragraph("Placeholder")
+    template_doc.save(template_path)
+    doc = create_cv(minimal_content(), template=str(template_path))
+    texts = [p.text for p in doc.paragraphs]
+    assert "Placeholder" in texts
+


### PR DESCRIPTION
## Summary
- add argparse-based CLI with input, output and template options
- allow `create_cv` to start from an optional template
- document new usage and dependency on `docxtpl`
- test CLI entry point and template support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7df0c3a88320a326985dfb6f58c5